### PR TITLE
Add CLI tools with multi-level progress tracking

### DIFF
--- a/backend/src/cli/README.md
+++ b/backend/src/cli/README.md
@@ -1,0 +1,255 @@
+# CLI Tools
+
+## Overview
+
+Command-line tools for the scraper-agent backend with real-time progress tracking.
+
+## Scrape CLI
+
+A command-line tool for scraping websites with real-time progress tracking.
+
+### Installation
+
+Make sure you have the required dependencies installed:
+
+```bash
+pip install -r requirements.txt
+```
+
+### Usage
+
+**Basic usage:**
+```bash
+python -m src.cli.scrape <url>
+```
+
+**With options:**
+```bash
+python -m src.cli.scrape <url> --mode <mode> --purpose "<description>"
+```
+
+### Examples
+
+**Scrape a single page:**
+```bash
+python -m src.cli.scrape https://example.com --mode single-page
+```
+
+**Scrape an entire website:**
+```bash
+python -m src.cli.scrape https://alteaactive.com/winnipeg/faq/ --mode whole-site --purpose "Scrape gym FAQ and information"
+```
+
+**Custom API endpoint:**
+```bash
+python -m src.cli.scrape https://example.com --api-url http://localhost:8000
+```
+
+**Adjust polling interval:**
+```bash
+python -m src.cli.scrape https://example.com --poll-interval 0.5
+```
+
+### Options
+
+- `url` (required): The URL to scrape
+- `--mode`: Scrape mode - either "single-page" or "whole-site" (default: "whole-site")
+- `--purpose`: Description of what you're scraping for (default: "General web scraping")
+- `--api-url`: API base URL (default: "http://localhost:8000")
+- `--poll-interval`: How often to poll for status updates in seconds (default: 1.0)
+
+### Output
+
+The CLI provides real-time updates with:
+- **Spinner animation** while scraping is in progress
+- **Page count** showing how many pages have been scraped
+- **Elapsed time** tracking
+- **Status updates** (pending → in progress → completed/failed)
+- **Final summary** with:
+  - Total pages scraped
+  - Duration
+  - List of scraped URLs
+  - Session ID for future reference
+
+### Example Session
+
+```bash
+$ python -m src.cli.scrape https://alteaactive.com/winnipeg/faq/
+
+Starting scrape of: https://alteaactive.com/winnipeg/faq/
+
+Session created: 20251126_143052_abc123
+
+⠋ Scraping... 15 pages scraped [00:23]
+
+╭─────────── Scrape Complete ───────────╮
+│ Status         COMPLETED              │
+│ URL            https://alteaactive... │
+│ Mode           whole-site             │
+│ Pages Scraped  27                     │
+│ Elapsed Time   45.3s                  │
+╰───────────────────────────────────────╯
+
+Scraped 27 URLs:
+  1. https://alteaactive.com/winnipeg/faq/
+  2. https://alteaactive.com/winnipeg/pricing/
+  3. https://alteaactive.com/winnipeg/schedule/
+  ... and 24 more
+
+Session ID: 20251126_143052_abc123
+```
+
+### Help
+
+For more information, use the `--help` flag:
+
+```bash
+python -m src.cli.scrape --help
+```
+
+---
+
+## Embed Sites CLI
+
+A command-line tool for embedding scraped website content into Milvus vector database with real-time progress tracking.
+
+### Installation
+
+Make sure you have the required dependencies installed and Milvus running:
+
+```bash
+pip install -r requirements.txt
+```
+
+### Commands
+
+The embed CLI has three main commands: `list`, `embed`, and `delete`.
+
+#### List Command
+
+List all available cleaned markdown files ready for embedding.
+
+```bash
+python -m src.cli.embed_sites list
+```
+
+**Example output:**
+```
+Available Cleaned Markdown Files (1)
+┏━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━┓
+┃ # ┃ Filename                               ┃ Gym/Site        ┃ Pages ┃
+┡━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━┩
+│ 1 │ fitfactoryfitness.com__20251125.json   │ FitFactory      │    56 │
+└───┴────────────────────────────────────────┴─────────────────┴───────┘
+```
+
+#### Embed Command
+
+Embed cleaned markdown files into Milvus with multi-level progress tracking.
+
+**Embed all files:**
+```bash
+python -m src.cli.embed_sites embed
+```
+
+**Embed a specific file:**
+```bash
+python -m src.cli.embed_sites embed --file fitfactoryfitness.com__20251125_155930.json
+```
+
+**Recreate collection and embed:**
+```bash
+python -m src.cli.embed_sites embed --recreate
+```
+
+**Options:**
+- `--file`: Specific file to embed (optional)
+- `--recreate`: Drop existing collection and recreate before embedding (optional flag)
+
+**Progress Display:**
+
+The embed command shows three levels of real-time progress:
+- **Files Progress**: Overall file processing (e.g., 1/1 files)
+- **Pages Progress**: Pages within current file (e.g., 56/56 pages)
+- **Chunks Progress**: Text chunks being embedded (e.g., 1/1 chunks)
+
+**Example output:**
+```
+Loading BGE-M3 embedding model...
+✓ Model loaded successfully
+
+Processing fitfactoryfitness.com__20251125.json... ━━━━━━━ 100% (1/1)
+  Pages:                                            ━━━━━━━ 100% (56/56)
+  Chunks:                                           ━━━━━━━ 100% (1/1)
+
+╭───────────────────── Embedding Complete ──────────────────────╮
+│   Files Processed    1/1                                      │
+│   Total Chunks       55                                       │
+│   Duration           12.5s                                    │
+│   Status             All files embedded successfully          │
+╰───────────────────────────────────────────────────────────────╯
+```
+
+#### Delete Command
+
+Delete the Milvus collection or specific domain data with confirmation prompts.
+
+**Delete entire collection (with confirmation):**
+```bash
+python -m src.cli.embed_sites delete
+```
+
+**Delete entire collection (skip confirmation):**
+```bash
+python -m src.cli.embed_sites delete --force
+```
+
+**Delete specific domain (with confirmation):**
+```bash
+python -m src.cli.embed_sites delete --domain fitfactoryfitness.com
+```
+
+**Delete specific domain (skip confirmation):**
+```bash
+python -m src.cli.embed_sites delete --domain fitfactoryfitness.com --force
+```
+
+**Options:**
+- `--domain`: Delete only data for a specific domain (optional)
+- `--force`: Skip confirmation prompt (optional flag)
+
+**Example output:**
+```bash
+$ python -m src.cli.embed_sites delete
+
+Are you sure you want to delete the entire collection 'gym_sites'? [y/N]: y
+Deleting collection: gym_sites
+✓ Collection 'gym_sites' deleted successfully
+```
+
+### Workflow Example
+
+Here's a typical workflow using all three commands:
+
+```bash
+# 1. Check what files are available
+python -m src.cli.embed_sites list
+
+# 2. Embed all files into Milvus
+python -m src.cli.embed_sites embed
+
+# 3. If you need to re-embed, delete and recreate
+python -m src.cli.embed_sites delete --force
+python -m src.cli.embed_sites embed
+
+# Or use the --recreate flag
+python -m src.cli.embed_sites embed --recreate
+```
+
+### Technical Details
+
+- **Embedding Model**: BGE-M3 (BAAI/bge-m3) with 1024-dimensional dense vectors
+- **Vector Database**: Milvus with HNSW index for fast similarity search
+- **Chunking Strategy**: Markdown-aware chunking with 4000 character max per chunk
+- **Progress Tracking**: Real-time progress bars using Rich library
+- **Safety Features**: Confirmation prompts for destructive operations (unless `--force` is used)

--- a/backend/src/cli/__init__.py
+++ b/backend/src/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI tools for batch processing."""

--- a/backend/src/cli/embed_sites.py
+++ b/backend/src/cli/embed_sites.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""CLI tool to embed cleaned markdown sites into Milvus vector database with progress tracking.
+
+Examples:
+    # List available files
+    python -m src.cli.embed_sites list
+
+    # Embed all cleaned markdown files
+    python -m src.cli.embed_sites embed
+
+    # Embed a specific file
+    python -m src.cli.embed_sites embed --file example.com__20251124_001545.json
+
+    # Recreate collection and embed all
+    python -m src.cli.embed_sites embed --recreate
+
+    # Delete entire collection (with confirmation)
+    python -m src.cli.embed_sites delete
+
+    # Delete entire collection (skip confirmation)
+    python -m src.cli.embed_sites delete --force
+
+    # Delete specific domain data
+    python -m src.cli.embed_sites delete --domain example.com
+
+    # Delete specific domain (skip confirmation)
+    python -m src.cli.embed_sites delete --domain example.com --force
+"""
+import time
+from typing import Optional, List
+import typer
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, BarColumn, TextColumn, TimeElapsedColumn
+from rich.panel import Panel
+from rich.table import Table
+
+from ..services import storage_service, vector_service
+from ..utils.logger import logger
+
+app = typer.Typer()
+console = Console()
+
+
+def list_files_table():
+    """Display available files in a nice table."""
+    files = storage_service.list_raw_html_files()
+
+    if not files:
+        console.print("[yellow]No cleaned markdown files found.[/yellow]")
+        return []
+
+    table = Table(title=f"Available Cleaned Markdown Files ({len(files)})")
+    table.add_column("#", style="cyan", no_wrap=True)
+    table.add_column("Filename", style="white")
+    table.add_column("Gym/Site", style="green")
+    table.add_column("Pages", style="yellow", justify="right")
+
+    for i, filename in enumerate(files, 1):
+        data = storage_service.load_raw_html(filename)
+        if data:
+            gym_name = data.get("gym_name", "Unknown")
+            page_count = str(len(data.get("pages", [])))
+            table.add_row(str(i), filename, gym_name, page_count)
+        else:
+            table.add_row(str(i), filename, "[red]Failed to load[/red]", "-")
+
+    console.print(table)
+    return files
+
+
+def embed_file_with_progress(
+    filename: str,
+    progress: Optional[Progress] = None,
+    file_task: Optional[int] = None,
+    page_task: Optional[int] = None,
+    chunk_task: Optional[int] = None
+) -> tuple[bool, int]:
+    """Embed a single file with progress tracking.
+
+    Args:
+        filename: Name of the file to embed
+        progress: Single Progress object for all progress bars
+        file_task: Task ID for file-level progress
+        page_task: Task ID for page-level progress
+        chunk_task: Task ID for chunk-level progress
+
+    Returns:
+        Tuple of (success: bool, total_chunks: int)
+    """
+    # Load cleaned markdown data
+    data = storage_service.load_raw_html(filename)
+    if not data:
+        logger.error(f"Failed to load file: {filename}")
+        return False, 0
+
+    domain = data.get("website", "unknown")
+    gym_name = data.get("gym_name", "Unknown Gym")
+    pages = data.get("pages", [])
+
+    if not pages:
+        logger.warning(f"No pages found in {filename}")
+        return False, 0
+
+    # Update page progress bar
+    if progress and page_task is not None:
+        progress.update(page_task, total=len(pages), completed=0)
+
+    # Initialize vector service
+    vector_service.create_collection()
+
+    # Process each page
+    total_chunks = 0
+    for page_idx, page in enumerate(pages):
+        page_name = page.get("page_name", "Unknown Page")
+        page_url = page.get("page_url", "")
+        markdown_content = page.get("markdown_content", "")
+
+        if not markdown_content:
+            logger.warning(f"Skipping empty page: {page_name}")
+            if progress and page_task is not None:
+                progress.advance(page_task)
+            continue
+
+        # Chunk the markdown
+        chunks = vector_service.chunk_markdown(markdown_content, page_name)
+
+        if not chunks:
+            logger.warning(f"No chunks extracted from {page_name}")
+            if progress and page_task is not None:
+                progress.advance(page_task)
+            continue
+
+        # Update chunk progress bar
+        if progress and chunk_task is not None:
+            progress.update(chunk_task, total=len(chunks), completed=0)
+
+        # Define progress callback for chunk embedding
+        def chunk_callback(current: int, total: int):
+            if progress and chunk_task is not None:
+                progress.update(chunk_task, completed=current)
+
+        # Insert chunks into Milvus with progress tracking
+        vector_service.insert_chunks(
+            domain=domain,
+            gym_name=gym_name,
+            page_name=page_name,
+            page_url=page_url,
+            chunks=chunks,
+            progress_callback=chunk_callback
+        )
+
+        total_chunks += len(chunks)
+
+        # Advance page progress
+        if progress and page_task is not None:
+            progress.advance(page_task)
+
+    # Advance file progress
+    if progress and file_task is not None:
+        progress.advance(file_task)
+
+    return True, total_chunks
+
+
+@app.command(name="list")
+def list_command():
+    """List all available cleaned markdown files."""
+    list_files_table()
+
+
+@app.command()
+def delete(
+    domain: Optional[str] = typer.Option(None, "--domain", help="Delete specific domain only"),
+    force: bool = typer.Option(False, "--force", is_flag=True, help="Skip confirmation prompt")
+):
+    """
+    Delete the Milvus collection or specific domain data.
+
+    By default, deletes the entire collection. Use --domain to delete specific domain data.
+    """
+    from pymilvus import utility, Collection
+
+    # Connect to Milvus
+    vector_service._connect()
+
+    if domain:
+        # Delete specific domain
+        if not force:
+            confirm = typer.confirm(f"Are you sure you want to delete all data for domain '{domain}'?")
+            if not confirm:
+                console.print("[yellow]Deletion cancelled[/yellow]")
+                return
+
+        if not utility.has_collection(vector_service.collection_name):
+            console.print(f"[red]Collection '{vector_service.collection_name}' does not exist[/red]")
+            return
+
+        console.print(f"[yellow]Deleting data for domain: {domain}[/yellow]")
+        vector_service.collection = Collection(vector_service.collection_name)
+        vector_service.delete_by_domain(domain)
+        console.print(f"[green]✓ Deleted all data for domain '{domain}'[/green]")
+    else:
+        # Delete entire collection
+        if not force:
+            confirm = typer.confirm(f"Are you sure you want to delete the entire collection '{vector_service.collection_name}'?")
+            if not confirm:
+                console.print("[yellow]Deletion cancelled[/yellow]")
+                return
+
+        if not utility.has_collection(vector_service.collection_name):
+            console.print(f"[yellow]Collection '{vector_service.collection_name}' does not exist[/yellow]")
+            return
+
+        console.print(f"[yellow]Deleting collection: {vector_service.collection_name}[/yellow]")
+        Collection(vector_service.collection_name).drop()
+        console.print(f"[green]✓ Collection '{vector_service.collection_name}' deleted successfully[/green]")
+
+
+@app.command()
+def embed(
+    file: Optional[str] = typer.Option(None, "--file", help="Specific file to embed"),
+    recreate: bool = typer.Option(False, "--recreate", is_flag=True, help="Recreate Milvus collection")
+):
+    """
+    Embed cleaned markdown files into Milvus vector database.
+
+    By default, embeds all available files. Use --file to embed a specific file.
+    """
+    # Recreate collection if requested
+    if recreate:
+        console.print("[yellow]⚠ Recreating Milvus collection (all existing data will be lost)[/yellow]")
+        from pymilvus import utility, Collection
+        vector_service._connect()
+        if utility.has_collection(vector_service.collection_name):
+            Collection(vector_service.collection_name).drop()
+            console.print("[green]✓ Dropped existing collection[/green]")
+
+    # Get files to embed
+    if file:
+        files = [file]
+        console.print(f"\n[bold cyan]Embedding file:[/bold cyan] {file}\n")
+    else:
+        files = storage_service.list_raw_html_files()
+        if not files:
+            console.print("[red]No cleaned markdown files found to embed[/red]")
+            raise typer.Exit(1)
+        console.print(f"\n[bold cyan]Embedding {len(files)} files...[/bold cyan]\n")
+
+    # Load model (no spinner to avoid conflicts with Progress bars)
+    console.print("[bold green]Loading BGE-M3 embedding model...[/bold green]")
+    vector_service.load_model()
+    console.print("[green]✓ Model loaded successfully[/green]\n")
+
+    # Create single progress bar with multiple tasks
+    start_time = time.time()
+    success_count = 0
+    total_chunks = 0
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        TextColumn("({task.completed}/{task.total})"),
+        console=console,
+        transient=False
+    ) as progress:
+
+        # Create progress tasks (all in the same Progress instance)
+        file_task = progress.add_task("[cyan]Files...", total=len(files))
+        page_task = progress.add_task("  [cyan]Pages:", total=0)
+        chunk_task = progress.add_task("  [green]Chunks:", total=0)
+
+        # Process each file
+        for filename in files:
+            progress.update(
+                file_task,
+                description=f"[cyan]Processing {filename[:50]}..."
+            )
+
+            try:
+                success, chunks = embed_file_with_progress(
+                    filename,
+                    progress, file_task,
+                    page_task,
+                    chunk_task
+                )
+
+                if success:
+                    success_count += 1
+                    total_chunks += chunks
+
+            except Exception as e:
+                logger.error(f"Failed to embed {filename}: {e}")
+                console.print(f"[red]✗ Failed: {filename}[/red]")
+                continue
+
+    # Calculate duration
+    duration = time.time() - start_time
+
+    # Show final summary
+    console.print("\n")
+
+    summary = Table(show_header=False, box=None, padding=(0, 2))
+    summary.add_column("Field", style="cyan bold")
+    summary.add_column("Value", style="white")
+
+    summary.add_row("Files Processed", f"{success_count}/{len(files)}")
+    summary.add_row("Total Chunks", str(total_chunks))
+    summary.add_row("Duration", f"{duration:.1f}s")
+
+    if success_count == len(files):
+        summary.add_row("Status", "[green]All files embedded successfully[/green]")
+        title_style = "green"
+        title = "Embedding Complete"
+    else:
+        summary.add_row("Status", f"[yellow]{len(files) - success_count} files failed[/yellow]")
+        title_style = "yellow"
+        title = "Embedding Completed with Errors"
+
+    console.print(Panel(
+        summary,
+        title=f"[{title_style}]{title}[/{title_style}]",
+        border_style=title_style
+    ))
+
+    if success_count < len(files):
+        raise typer.Exit(1)
+
+
+if __name__ == "__main__":
+    app()

--- a/backend/src/cli/scrape.py
+++ b/backend/src/cli/scrape.py
@@ -1,0 +1,211 @@
+"""CLI tool for scraping websites with real-time progress tracking."""
+import asyncio
+import time
+from typing import Optional
+import httpx
+import typer
+from rich.console import Console
+from rich.live import Live
+from rich.panel import Panel
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+from rich.table import Table
+
+app = typer.Typer()
+console = Console()
+
+
+async def start_scrape(
+    url: str,
+    mode: str,
+    purpose: str,
+    api_url: str
+) -> Optional[str]:
+    """Initiate a scrape and return the session ID."""
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            response = await client.post(
+                f"{api_url}/api/scrape",
+                json={
+                    "url": url,
+                    "mode": mode,
+                    "purpose": purpose
+                }
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data.get("session_id")
+        except httpx.HTTPStatusError as e:
+            console.print(f"[red]Error starting scrape: {e.response.text}[/red]")
+            return None
+        except Exception as e:
+            console.print(f"[red]Error: {e}[/red]")
+            return None
+
+
+async def get_session_status(session_id: str, api_url: str) -> Optional[dict]:
+    """Get the current status of a scraping session."""
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            response = await client.get(f"{api_url}/api/sessions/{session_id}")
+            response.raise_for_status()
+            return response.json()
+        except Exception:
+            return None
+
+
+def create_status_display(session_data: dict, elapsed: float) -> Table:
+    """Create a rich table displaying the current scrape status."""
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Field", style="cyan bold", no_wrap=True)
+    table.add_column("Value", style="white")
+
+    status = session_data.get("status", "unknown")
+    pages_scraped = session_data.get("pages_scraped", 0)
+    url = session_data.get("url", "")
+    mode = session_data.get("mode", "")
+
+    # Status with color
+    status_colors = {
+        "pending": "yellow",
+        "in_progress": "blue",
+        "completed": "green",
+        "failed": "red"
+    }
+    status_color = status_colors.get(status, "white")
+
+    table.add_row("Status", f"[{status_color}]{status.upper()}[/{status_color}]")
+    table.add_row("URL", url)
+    table.add_row("Mode", mode)
+    table.add_row("Pages Scraped", str(pages_scraped))
+    table.add_row("Elapsed Time", f"{elapsed:.1f}s")
+
+    if status == "failed":
+        error_msg = session_data.get("error_message", "Unknown error")
+        table.add_row("Error", f"[red]{error_msg}[/red]")
+
+    return table
+
+
+async def track_scrape_progress(
+    session_id: str,
+    api_url: str,
+    poll_interval: float = 1.0
+) -> bool:
+    """Track scraping progress with live updates."""
+    start_time = time.time()
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        TimeElapsedColumn(),
+        console=console,
+        transient=False
+    ) as progress:
+        task = progress.add_task("[cyan]Initializing...", total=None)
+
+        while True:
+            elapsed = time.time() - start_time
+            session_data = await get_session_status(session_id, api_url)
+
+            if not session_data:
+                progress.update(task, description="[red]Failed to get status")
+                await asyncio.sleep(poll_interval)
+                continue
+
+            status = session_data.get("status", "unknown")
+            pages_scraped = session_data.get("pages_scraped", 0)
+
+            # Update progress description
+            if status == "pending":
+                progress.update(task, description="[yellow]Starting scrape...")
+            elif status == "in_progress":
+                progress.update(
+                    task,
+                    description=f"[cyan]Scraping... {pages_scraped} pages scraped"
+                )
+            elif status == "completed":
+                duration = session_data.get("duration_seconds", elapsed)
+                progress.update(
+                    task,
+                    description=f"[green]Completed! {pages_scraped} pages scraped in {duration:.1f}s"
+                )
+                progress.stop()
+
+                # Show final summary
+                console.print("\n")
+                console.print(Panel(
+                    create_status_display(session_data, duration),
+                    title="[green]Scrape Complete",
+                    border_style="green"
+                ))
+
+                # Show scraped URLs
+                sources = session_data.get("sources", [])
+                if sources:
+                    console.print(f"\n[cyan]Scraped {len(sources)} URLs:[/cyan]")
+                    for i, source in enumerate(sources[:10], 1):
+                        console.print(f"  {i}. {source}")
+                    if len(sources) > 10:
+                        console.print(f"  ... and {len(sources) - 10} more")
+
+                console.print(f"\n[cyan]Session ID:[/cyan] {session_id}")
+                return True
+
+            elif status == "failed":
+                error_msg = session_data.get("error_message", "Unknown error")
+                progress.update(task, description=f"[red]Failed: {error_msg}")
+                progress.stop()
+
+                console.print("\n")
+                console.print(Panel(
+                    create_status_display(session_data, elapsed),
+                    title="[red]Scrape Failed",
+                    border_style="red"
+                ))
+                return False
+
+            await asyncio.sleep(poll_interval)
+
+
+@app.command()
+def scrape(
+    url: str = typer.Argument(..., help="URL to scrape"),
+    mode: str = typer.Option("whole-site", help="Scrape mode: 'single-page' or 'whole-site'"),
+    purpose: str = typer.Option("General web scraping", help="Purpose of the scrape"),
+    api_url: str = typer.Option("http://localhost:8000", help="API base URL"),
+    poll_interval: float = typer.Option(1.0, help="Polling interval in seconds")
+):
+    """
+    Scrape a website with real-time progress tracking.
+
+    Examples:
+
+        python -m src.cli.scrape https://example.com
+
+        python -m src.cli.scrape https://example.com --mode single-page
+
+        python -m src.cli.scrape https://example.com --purpose "Scrape gym information"
+    """
+    console.print(f"\n[bold cyan]Starting scrape of:[/bold cyan] {url}\n")
+
+    async def run():
+        # Start the scrape
+        session_id = await start_scrape(url, mode, purpose, api_url)
+
+        if not session_id:
+            console.print("[red]Failed to start scrape[/red]")
+            raise typer.Exit(1)
+
+        console.print(f"[green]Session created:[/green] {session_id}\n")
+
+        # Track progress
+        success = await track_scrape_progress(session_id, api_url, poll_interval)
+
+        if not success:
+            raise typer.Exit(1)
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    app()

--- a/backend/src/services/vector_service.py
+++ b/backend/src/services/vector_service.py
@@ -1,0 +1,412 @@
+"""Vector database service using Milvus with BGE-M3 embeddings."""
+import os
+# Disable HuggingFace progress bars before any imports
+os.environ['HF_HUB_DISABLE_PROGRESS_BARS'] = '1'
+os.environ['TRANSFORMERS_VERBOSITY'] = 'error'
+
+import json
+from pathlib import Path
+from typing import List, Dict, Any, Optional, Tuple, Callable
+from pymilvus import (
+    connections,
+    Collection,
+    CollectionSchema,
+    FieldSchema,
+    DataType,
+    utility,
+)
+from FlagEmbedding import BGEM3FlagModel
+
+from ..config import settings
+from ..utils.logger import logger
+from .html_cleaner import html_cleaner
+
+
+class VectorService:
+    """Service for embedding and vector search with Milvus + BGE-M3."""
+
+    def __init__(
+        self,
+        collection_name: str = "gym_sites",
+        milvus_host: str = None,
+        milvus_port: int = 19530,
+    ):
+        """Initialize the vector service.
+
+        Args:
+            collection_name: Name of the Milvus collection
+            milvus_host: Milvus server host (defaults to env var or 'localhost')
+            milvus_port: Milvus server port
+        """
+        import os
+
+        self.collection_name = collection_name
+        # Get host from environment or parameter or default to localhost
+        self.milvus_host = milvus_host or os.getenv("MILVUS_HOST", "localhost")
+        self.milvus_port = int(os.getenv("MILVUS_PORT", milvus_port))
+        self.collection: Optional[Collection] = None
+        self.connected = False
+
+        # BGE-M3 model for hybrid dense + sparse embeddings
+        self.model: Optional[BGEM3FlagModel] = None
+
+    def _connect(self):
+        """Connect to Milvus server (lazy initialization)."""
+        if self.connected:
+            return
+
+        try:
+            # Connect to standalone Milvus server
+            connections.connect(
+                alias="default",
+                host=self.milvus_host,
+                port=self.milvus_port,
+            )
+            self.connected = True
+            logger.info(f"Connected to Milvus at {self.milvus_host}:{self.milvus_port}")
+        except Exception as e:
+            logger.error(f"Failed to connect to Milvus at {self.milvus_host}:{self.milvus_port}: {e}")
+            raise
+
+    def load_model(self):
+        """Load BGE-M3 embedding model."""
+        if self.model is None:
+            logger.info("Loading BGE-M3 embedding model...")
+            self.model = BGEM3FlagModel('BAAI/bge-m3', use_fp16=True)
+            logger.info("BGE-M3 model loaded successfully")
+
+    def create_collection(self, dim: int = 1024):
+        """Create Milvus collection with hybrid search support.
+
+        Args:
+            dim: Dimension of dense embeddings (BGE-M3 uses 1024)
+        """
+        # Ensure connected
+        self._connect()
+
+        if utility.has_collection(self.collection_name):
+            logger.info(f"Collection '{self.collection_name}' already exists")
+            self.collection = Collection(self.collection_name)
+            return
+
+        # Define collection schema
+        fields = [
+            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True, auto_id=True),
+            FieldSchema(name="chunk_id", dtype=DataType.VARCHAR, max_length=256),
+            FieldSchema(name="domain", dtype=DataType.VARCHAR, max_length=256),
+            FieldSchema(name="gym_name", dtype=DataType.VARCHAR, max_length=256),
+            FieldSchema(name="page_name", dtype=DataType.VARCHAR, max_length=256),
+            FieldSchema(name="page_url", dtype=DataType.VARCHAR, max_length=512),
+            FieldSchema(name="chunk_text", dtype=DataType.VARCHAR, max_length=8192),
+            FieldSchema(name="dense_vector", dtype=DataType.FLOAT_VECTOR, dim=dim),
+            # Note: Milvus v2.4+ supports sparse vectors, but we'll use dense for now
+        ]
+
+        schema = CollectionSchema(
+            fields=fields,
+            description="Gym website chunks with BGE-M3 embeddings"
+        )
+
+        self.collection = Collection(
+            name=self.collection_name,
+            schema=schema,
+            using="default"
+        )
+
+        # Create index for dense vectors (HNSW for fast ANN search)
+        index_params = {
+            "metric_type": "IP",  # Inner product (cosine similarity for normalized vectors)
+            "index_type": "HNSW",
+            "params": {"M": 16, "efConstruction": 200}
+        }
+
+        self.collection.create_index(
+            field_name="dense_vector",
+            index_params=index_params
+        )
+
+        logger.info(f"Created collection '{self.collection_name}' with HNSW index")
+
+    def embed_text(self, text: str) -> Tuple[List[float], Dict[str, float]]:
+        """Embed text using BGE-M3 (dense + sparse).
+
+        Args:
+            text: Text to embed
+
+        Returns:
+            Tuple of (dense_vector, sparse_vector_dict)
+        """
+        if self.model is None:
+            self.load_model()
+
+        # BGE-M3 returns dense, sparse, and colbert embeddings
+        # We'll use dense for now (sparse requires Milvus v2.4+ full support)
+        embeddings = self.model.encode(
+            [text],
+            return_dense=True,
+            return_sparse=True,
+            return_colbert_vecs=False
+        )
+
+        dense_vector = embeddings['dense_vecs'][0].tolist()
+        sparse_vector = embeddings['lexical_weights'][0]  # Dict format
+
+        return dense_vector, sparse_vector
+
+    def chunk_html(self, html: str, page_name: str, max_chunk_size: int = 1000) -> List[Dict[str, str]]:
+        """Chunk HTML intelligently for embedding using HTML cleaner.
+
+        Args:
+            html: Raw HTML content
+            page_name: Name of the page (for metadata)
+            max_chunk_size: Maximum characters per chunk
+
+        Returns:
+            List of chunk dicts with text and metadata
+        """
+        # Use HTML cleaner to extract clean, structured chunks
+        chunks = html_cleaner.clean_and_chunk(
+            html=html,
+            page_name=page_name,
+            chunk_size=max_chunk_size,
+            overlap=200  # 20% overlap for context
+        )
+
+        logger.debug(f"Chunked '{page_name}' into {len(chunks)} clean chunks")
+        return chunks
+
+    def chunk_markdown(self, markdown: str, page_name: str, max_chunk_size: int = 4000) -> List[Dict[str, str]]:
+        """Chunk markdown intelligently for embedding.
+
+        Args:
+            markdown: Cleaned markdown content
+            page_name: Name of the page (for metadata)
+            max_chunk_size: Maximum characters per chunk (default 4000 to stay well below 8192 limit)
+
+        Returns:
+            List of chunk dicts with text and metadata
+        """
+        if not markdown or not markdown.strip():
+            return []
+
+        chunks = []
+        lines = markdown.split('\n')
+        current_chunk = []
+        current_size = 0
+        current_heading = ""
+
+        for line in lines:
+            # Track headings for context
+            if line.startswith('#'):
+                current_heading = line.strip('# ').strip()
+
+            line_len = len(line) + 1  # +1 for newline
+
+            # If adding this line would exceed max size, save current chunk
+            if current_size + line_len > max_chunk_size and current_chunk:
+                chunk_text = '\n'.join(current_chunk).strip()
+                if chunk_text:
+                    # Ensure chunk is under 8000 chars (safety margin for 8192 limit)
+                    if len(chunk_text) > 8000:
+                        chunk_text = chunk_text[:8000]
+                    chunks.append({
+                        "text": chunk_text,
+                        "heading": current_heading,
+                        "page_name": page_name
+                    })
+                current_chunk = [line]
+                current_size = line_len
+            else:
+                current_chunk.append(line)
+                current_size += line_len
+
+        # Add final chunk
+        if current_chunk:
+            chunk_text = '\n'.join(current_chunk).strip()
+            if chunk_text:
+                # Ensure chunk is under 8000 chars (safety margin for 8192 limit)
+                if len(chunk_text) > 8000:
+                    chunk_text = chunk_text[:8000]
+                chunks.append({
+                    "text": chunk_text,
+                    "heading": current_heading,
+                    "page_name": page_name
+                })
+
+        logger.debug(f"Chunked '{page_name}' into {len(chunks)} markdown chunks")
+        return chunks
+
+    def insert_chunks(
+        self,
+        domain: str,
+        gym_name: str,
+        page_name: str,
+        page_url: str,
+        chunks: List[Dict[str, str]],
+        progress_callback: Optional[Callable[[int, int], None]] = None
+    ):
+        """Insert chunked and embedded text into Milvus.
+
+        Args:
+            domain: Website domain
+            gym_name: Gym/studio name
+            page_name: Page name
+            page_url: Page URL
+            chunks: List of text chunks
+            progress_callback: Optional callback function(current, total) for progress tracking
+        """
+        if self.collection is None:
+            self.create_collection()
+
+        if not chunks:
+            logger.warning(f"No chunks to insert for {page_url}")
+            return
+
+        # Load model if needed
+        if self.model is None:
+            self.load_model()
+
+        # Prepare data for insertion
+        chunk_ids = []
+        domains = []
+        gym_names = []
+        page_names = []
+        page_urls = []
+        chunk_texts = []
+        dense_vectors = []
+
+        for i, chunk in enumerate(chunks):
+            chunk_id = f"{domain}_{page_name}_{i}"
+            chunk_text = chunk["text"]
+
+            # Embed chunk
+            dense_vec, sparse_vec = self.embed_text(chunk_text)
+
+            chunk_ids.append(chunk_id)
+            domains.append(domain)
+            gym_names.append(gym_name)
+            page_names.append(page_name)
+            page_urls.append(page_url)
+            # Ensure text is well under 8192 limit (use 8000 for safety)
+            safe_chunk_text = chunk_text[:8000] if len(chunk_text) > 8000 else chunk_text
+            chunk_texts.append(safe_chunk_text)
+            dense_vectors.append(dense_vec)
+
+            # Report progress if callback provided
+            if progress_callback:
+                progress_callback(i + 1, len(chunks))
+
+        # Insert into Milvus
+        data = [
+            chunk_ids,
+            domains,
+            gym_names,
+            page_names,
+            page_urls,
+            chunk_texts,
+            dense_vectors,
+        ]
+
+        self.collection.insert(data)
+        # Note: flush() is optional and can cause issues with Milvus Lite
+        # Data will be persisted automatically
+
+        logger.info(f"Inserted {len(chunks)} chunks for {domain}/{page_name}")
+
+    def search(
+        self,
+        query: str,
+        top_k: int = 20,
+        filter_domain: Optional[str] = None,
+        filter_gym: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """Search for relevant chunks using hybrid dense search.
+
+        Args:
+            query: Search query
+            top_k: Number of results to return
+            filter_domain: Optional domain filter
+            filter_gym: Optional gym name filter
+
+        Returns:
+            List of search results with chunks and metadata
+        """
+        # Connect and get collection if not already done
+        if self.collection is None:
+            self._connect()
+            if utility.has_collection(self.collection_name):
+                self.collection = Collection(self.collection_name)
+            else:
+                logger.error(f"Collection '{self.collection_name}' does not exist")
+                return []
+
+        # Load collection into memory
+        self.collection.load()
+
+        # Embed query
+        dense_vec, sparse_vec = self.embed_text(query)
+
+        # Build filter expression
+        filter_expr = None
+        if filter_domain:
+            filter_expr = f'domain == "{filter_domain}"'
+        if filter_gym:
+            gym_filter = f'gym_name == "{filter_gym}"'
+            filter_expr = f"{filter_expr} && {gym_filter}" if filter_expr else gym_filter
+
+        # Search with dense vectors
+        search_params = {
+            "metric_type": "IP",
+            "params": {"ef": 64}
+        }
+
+        results = self.collection.search(
+            data=[dense_vec],
+            anns_field="dense_vector",
+            param=search_params,
+            limit=top_k,
+            expr=filter_expr,
+            output_fields=["chunk_id", "domain", "gym_name", "page_name", "page_url", "chunk_text"]
+        )
+
+        # Format results
+        formatted_results = []
+        for hits in results:
+            for hit in hits:
+                formatted_results.append({
+                    "chunk_id": hit.entity.get("chunk_id"),
+                    "domain": hit.entity.get("domain"),
+                    "gym_name": hit.entity.get("gym_name"),
+                    "page_name": hit.entity.get("page_name"),
+                    "page_url": hit.entity.get("page_url"),
+                    "chunk_text": hit.entity.get("chunk_text"),
+                    "score": hit.score,
+                })
+
+        logger.info(f"Search for '{query}' returned {len(formatted_results)} results")
+        return formatted_results
+
+    def delete_by_domain(self, domain: str):
+        """Delete all chunks for a specific domain.
+
+        Args:
+            domain: Domain to delete
+        """
+        if self.collection is None:
+            logger.error("Collection not loaded")
+            return
+
+        expr = f'domain == "{domain}"'
+        self.collection.delete(expr)
+        logger.info(f"Deleted all chunks for domain: {domain}")
+
+    def close(self):
+        """Close Milvus connection."""
+        if self.collection:
+            self.collection.release()
+        connections.disconnect("default")
+        logger.info("Disconnected from Milvus")
+
+
+# Global instance
+vector_service = VectorService()


### PR DESCRIPTION
New Features:
- Scrape CLI: Real-time progress tracking for website scraping
  * Commands: python -m src.cli.scrape <url>
  * Options: --mode (single-page/whole-site), --purpose, --poll-interval
  * Live progress with spinner, page count, elapsed time
  * Final summary with scraped URLs and session ID

- Embed Sites CLI: Multi-level progress tracking for vector embeddings
  * Commands: list, embed, delete
  * Three-level progress bars (Files → Pages → Chunks)
  * Options: --file (specific file), --recreate (drop/recreate collection)
  * Delete commands with confirmation prompts (--domain, --force)

Technical Changes:
- vector_service.py: Added progress_callback parameter to insert_chunks()
- Disabled HuggingFace progress bars to avoid conflicts with Rich Progress
- Single Progress object with multiple tasks for hierarchical tracking
- Typer commands instead of boolean flags for cleaner CLI structure

Documentation:
- Comprehensive README.md with usage examples and technical details
- Command examples for all CLI operations
- Workflow examples and best practices